### PR TITLE
Fix bulb address calculation when there are more than 2 strings in a group.

### DIFF
--- a/G35StringGroup.cpp
+++ b/G35StringGroup.cpp
@@ -35,9 +35,12 @@ uint16_t G35StringGroup::get_light_count() {
 void G35StringGroup::set_color(uint8_t bulb, uint8_t intensity, color_t color) {
   uint8_t string = 0;
   while (bulb >= string_offsets_[string] && string < string_count_) {
-    bulb -= string_offsets_[string++];
+    string++;
   }
   if (string < string_count_) {
+    if (string > 0) {
+      bulb -= string_offsets_[string - 1];
+    }
     strings_[string]->set_color(bulb, intensity, color);
   } else {
     // A program is misbehaving.


### PR DESCRIPTION
Hi Mike,

Thanks for the excellent library! 

I found an issue with the bulb address that gets calculated when there are more than 2 strings in a group. Can you take a look at this change?

Thanks,
Gregg.
